### PR TITLE
fix: 修复搜索时链接高亮文本图标显示问题

### DIFF
--- a/style/custom/link-icon.css
+++ b/style/custom/link-icon.css
@@ -1,7 +1,5 @@
 /* ———————————————————————————————————————————————————为链接前的icon图标设置格式———————————————————————————————————————————————— */
-.protyle-wysiwyg [data-node-id] span[data-type='a']:not(:empty)::before,
-.b3-typography a:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a:not(:empty)::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a']:first-child:not(:empty)::before {
     display: inline-block;
     position: relative;
     background-repeat: no-repeat;
@@ -13,725 +11,510 @@
 }
 
 /* ————————————————————为常见的文件格式设置图标———————————————————— */
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href^="file://"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href^="file://"]::before,
-.b3-typography a[href^="file://"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href^="file://"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/fold/folder.svg');
 }
 
 /* ————————————————————为没有收集icon图标的网站设置格式—————————————————— */
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href ^="http"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href ^="http"]::before,
-.b3-typography a[href ^="http"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href ^="http"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/link2.svg');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="weibo.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="weibo.com"]::before,
-.b3-typography a[href *="weibo.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="weibo.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/weibo_com.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="zhihu.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="zhihu.com"]::before,
-.b3-typography a[href *="zhihu.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="zhihu.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/zhihu_com.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="t.bilibili.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="t.bilibili.com"]::before,
-.b3-typography a[href *="t.bilibili.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="t.bilibili.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/t_bilibili_com.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="bilibili.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="bilibili.com"]::before,
-.b3-typography a[href *="bilibili.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="bilibili.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/bilibili_com.png');
 }
 
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="douban.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="douban.com"]::before,
-.b3-typography a[href *="douban.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="douban.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/douban_com.png');
 }
 
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="oschina.net"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="oschina.net"]::before,
-.b3-typography a[href *="oschina.net"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="oschina.net"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/oschina_net.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="ld246.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="ld246.com"]::before,
-.b3-typography a[href *="ld246.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="ld246.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/ld246_com.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="music.163.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="music.163.com"]::before,
-.b3-typography a[href *="music.163.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="music.163.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/music_163_com.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="runoob.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="runoob.com"]::before,
-.b3-typography a[href *="runoob.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="runoob.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/runoob_com.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="iconfont.cn"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="iconfont.cn"]::before,
-.b3-typography a[href *="iconfont.cn"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="iconfont.cn"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/iconfont_cn.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="pan.baidu.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="pan.baidu.com"]::before,
-.b3-typography a[href *="pan.baidu.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="pan.baidu.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/pan_baidu_com.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="yuque.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="yuque.com"]::before,
-.b3-typography a[href *="yuque.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="yuque.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/yuque_com.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="52pojie.cn"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="52pojie.cn"]::before,
-.b3-typography a[href *="52pojie.cn"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="52pojie.cn"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/52pojie_cn.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="sspai.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="sspai.com"]::before,
-.b3-typography a[href *="sspai.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="sspai.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/sspai_com.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="uisdc.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="uisdc.com"]::before,
-.b3-typography a[href *="uisdc.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="uisdc.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/uisdc_com.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="cn.bing.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="cn.bing.com"]::before,
-.b3-typography a[href *="cn.bing.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="cn.bing.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/cn_bing_com.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="jianshu.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="jianshu.com"]::before,
-.b3-typography a[href *="jianshu.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="jianshu.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/jianshu_com.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="blog.csdn.net"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="blog.csdn.net"]::before,
-.b3-typography a[href *="blog.csdn.net"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="blog.csdn.net"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/blog_csdn_net.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="zcool.com.cn"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="zcool.com.cn"]::before,
-.b3-typography a[href *="zcool.com.cn"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="zcool.com.cn"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/zcool_com_cn.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="ixigua.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="ixigua.com"]::before,
-.b3-typography a[href *="ixigua.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="ixigua.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/ixigua_com.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="weixin.sogou.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="weixin.sogou.com"]::before,
-.b3-typography a[href *="weixin.sogou.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="weixin.sogou.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/weixin_sogou_com.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="baidu.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="baidu.com"]::before,
-.b3-typography a[href *="baidu.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="baidu.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/baidu_com.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="tieba.baidu.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="tieba.baidu.com"]::before,
-.b3-typography a[href *="tieba.baidu.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="tieba.baidu.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/tieba_baidu_com.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="fanyi.baidu.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="fanyi.baidu.com"]::before,
-.b3-typography a[href *="fanyi.baidu.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="fanyi.baidu.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/fanyi_baidu_com.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="iplaysoft.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="iplaysoft.com"]::before,
-.b3-typography a[href *="iplaysoft.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="iplaysoft.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/iplaysoft_com.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="huaban.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="huaban.com"]::before,
-.b3-typography a[href *="huaban.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="huaban.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/huaban_com.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="v.qq.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="v.qq.com"]::before,
-.b3-typography a[href *="v.qq.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="v.qq.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/v_qq_com.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="iqiyi.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="iqiyi.com"]::before,
-.b3-typography a[href *="iqiyi.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="iqiyi.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/iqiyi_com.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="youku.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="youku.com"]::before,
-.b3-typography a[href *="youku.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="youku.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/youku_com.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="haokan.baidu.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="haokan.baidu.com"]::before,
-.b3-typography a[href *="haokan.baidu.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="haokan.baidu.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/haokan_baidu_com.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="y.qq.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="y.qq.com"]::before,
-.b3-typography a[href *="y.qq.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="y.qq.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/y_qq_com.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="kugou.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="kugou.com"]::before,
-.b3-typography a[href *="kugou.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="kugou.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/kugou_com.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="kuwo.cn"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="kuwo.cn"]::before,
-.b3-typography a[href *="kuwo.cn"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="kuwo.cn"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/kuwo_cn.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="toutiao.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="toutiao.com"]::before,
-.b3-typography a[href *="toutiao.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="toutiao.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/toutiao_com.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="tianya.cn"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="tianya.cn"]::before,
-.b3-typography a[href *="tianya.cn"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="tianya.cn"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/tianya_cn.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="bbs.hupu.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="bbs.hupu.com"]::before,
-.b3-typography a[href *="bbs.hupu.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="bbs.hupu.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/bbs_hupu_com.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="wiz.cn"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="wiz.cn"]::before,
-.b3-typography a[href *="wiz.cn"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="wiz.cn"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/wiz_cn.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="yinxiang.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="yinxiang.com"]::before,
-.b3-typography a[href *="yinxiang.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="yinxiang.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/yinxiang_com.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="logseq.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="logseq.com"]::before,
-.b3-typography a[href *="logseq.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="logseq.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/logseq_com.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="obsidian.md"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="obsidian.md"]::before,
-.b3-typography a[href *="obsidian.md"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="obsidian.md"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/obsidian_md.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="taobao.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="taobao.com"]::before,
-.b3-typography a[href *="taobao.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="taobao.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/taobao_com.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="so.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="so.com"]::before,
-.b3-typography a[href *="so.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="so.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/so_com.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="mp.weixin.qq.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="mp.weixin.qq.com"]::before,
-.b3-typography a[href *="mp.weixin.qq.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="mp.weixin.qq.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/mp_weixin_qq_com.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="yandex.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="yandex.com"]::before,
-.b3-typography a[href *="yandex.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="yandex.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/yandex_com.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="wolai.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="wolai.com"]::before,
-.b3-typography a[href *="wolai.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="wolai.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/wolai_com.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="auth.alipay.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="auth.alipay.com"]::before,
-.b3-typography a[href *="auth.alipay.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="auth.alipay.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/auth_alipay_com.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="aliyundrive.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="aliyundrive.com"]::before,
-.b3-typography a[href *="aliyundrive.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="aliyundrive.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/aliyundrive_com.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="baike.baidu.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="baike.baidu.com"]::before,
-.b3-typography a[href *="baike.baidu.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="baike.baidu.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/baike_baidu_com.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="apple.com.cn"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="apple.com.cn"]::before,
-.b3-typography a[href *="apple.com.cn"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="apple.com.cn"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/apple_com_cn.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="huawei.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="huawei.com"]::before,
-.b3-typography a[href *="huawei.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="huawei.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/huawei_com.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="samsung.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="samsung.com"]::before,
-.b3-typography a[href *="samsung.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="samsung.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/samsung_com.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="mi.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="mi.com"]::before,
-.b3-typography a[href *="mi.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="mi.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/mi_com.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="oppo.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="oppo.com"]::before,
-.b3-typography a[href *="oppo.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="oppo.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/oppo_com.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="vivo.com.cn"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="vivo.com.cn"]::before,
-.b3-typography a[href *="vivo.com.cn"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="vivo.com.cn"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/vivo_com_cn.png');
 }
 
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="topbook.cc"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="topbook.cc"]::before,
-.b3-typography a[href *="topbook.cc"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="topbook.cc"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/topbook_cc.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="appinn.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="appinn.com"]::before,
-.b3-typography a[href *="appinn.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="appinn.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/appinn_com.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="ghxi.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="ghxi.com"]::before,
-.b3-typography a[href *="ghxi.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="ghxi.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/ghxi_com.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="weread.qq.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="weread.qq.com"]::before
-.b3-typography a[href *="weread.qq.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="weread.qq.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/weread_qq_com.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="news.qq.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="news.qq.com"]::before,
-.b3-typography a[href *="news.qq.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="news.qq.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/news_qq_com.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="news.163.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="news.163.com"]::before,
-.b3-typography a[href *="news.163.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="news.163.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/news_163_com.png');
 }
 
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="guancha.cn"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="guancha.cn"]::before,
-.b3-typography a[href *="guancha.cn"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="guancha.cn"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/guancha_cn.png');
 }
 
 /* pocket */
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="getpocket.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="getpocket.com"]::before,
-.b3-typography a[href *="getpocket.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="getpocket.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/getpocket_com.png');
 }
 
 /* instapaper */
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="instapaper.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="instapaper.com"]::before,
-.b3-typography a[href *="instapaper.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="instapaper.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/instapaper_com.png');
 }
 
 /* GitHub */
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="github.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="github.com"]::before,
-.b3-typography a[href *="github.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="github.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/github_com.png');
 }
 
 /* 谷歌翻译 */
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="translate.google.cn"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="translate.google.cn"]::before,
-.b3-typography a[href *="translate.google.cn"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="translate.google.cn"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/translate_google_cn.png');
 }
 
 
 /* zotero */
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="zotero"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="zotero"]::before,
-.b3-typography a[href *="zotero"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="zotero"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/zotero.png');
 }
 
 /* 搜狐 */
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="sohu.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="sohu.com"]::before,
-.b3-typography a[href *="sohu.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="sohu.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/souhu.svg');
 }
 
 /* 豌豆荚 */
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="wandoujia.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="wandoujia.com"]::before,
-.b3-typography a[href *="wandoujia.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="wandoujia.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/wandou.svg');
 }
 
 /* Reddit */
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="redditinc.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="redditinc.com"]::before,
-.b3-typography a[href *="redditinc.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="redditinc.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/reddit.svg');
 }
 
 /* Instagram.com */
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="Instagram.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="Instagram.com"]::before,
-.b3-typography a[href *="Instagram.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="Instagram.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/ins.svg');
 }
 
 /* twitter.com */
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="twitter.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="twitter.com"]::before,
-.b3-typography a[href *="twitter.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="twitter.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/Twitter.svg');
 }
 
 /* facebook.com */
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="facebook.com"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="facebook.com"]::before,
-.b3-typography a[href *="facebook.com"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="facebook.com"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/Facebook.svg');
 }
 
 /* notion */
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="notion"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href *="notion"]::before,
-.b3-typography a[href *="notion"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="notion"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/notion.svg');
 }
 
 /* Youtube */
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href *="youtube"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id]a[href *="youtube"]::before,
-.b3-typography a[href *="youtube"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href *="youtube"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/youtube.svg');
 }
 /* bookxnote */
-.protyle-wysiwyg [data-node-id] span[data-type~='a'][data-href^="bookxnotepro://"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href^="bookxnotepro://"]::before,
-.b3-typography a[href^="bookxnotepro://"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href^="bookxnotepro://"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/bookxnote.ico');
 }
 /* liquidtext */
-.protyle-wysiwyg [data-node-id] span[data-type~='a'][data-href^="lt://"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href^="lt://"]::before,
-.b3-typography a[href^="lt://"]::before
-{
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href^="lt://"]:first-child:not(:empty)::before{
 	content:"";
 	background-image:url("/appearance/themes/Savor/icon/liquidtext.svg")
 }
 /* ————————————————————为常见的文件格式设置图标———————————————————— */
 /* 文件夹 */
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href^="file://"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href^="file://"]::before,
-.b3-typography a[href^="file://"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href^="file://"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/fold/folder.svg');
 }
 
 /* 压缩包 */
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href $=".zip"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href $=".zip"]::before,
-.b3-typography a[href ^="assets/"][href $=".zip"]::before,
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href $=".rar"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href $=".rar"]::before,
-.b3-typography a[href ^="assets/"][href $=".rar"]::before,
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href $=".7z"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href $=".7z"]::before,
-.b3-typography a[href ^="assets/"][href $=".7z"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href $=".zip"]:first-child:not(:empty)::before,
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href $=".rar"]:first-child:not(:empty)::before,
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href $=".7z"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/fold/zip.svg');
 }
 
 /* word */
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href $=".docx"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href $=".docx"]::before,
-.b3-typography [href ^="assets/"][href $=".docx"]::before,
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href $=".doc"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href $=".doc"]::before,
-.b3-typography [href ^="assets/"][href $=".doc"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href $=".docx"]:first-child:not(:empty)::before,
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href $=".doc"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/fold/word.svg');
 }
 
 /* ppt */
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href $=".pptx"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href $=".pptx"]::before,
-.b3-typography [href ^="assets/"][href $=".pptx"]::before,
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href $=".ppt"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href $=".ppt"]::before,
-.b3-typography [href ^="assets/"][href $=".ppt"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href $=".pptx"]:first-child:not(:empty)::before,
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href $=".ppt"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/fold/ppt.svg');
 }
 
 /* excel */
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href $=".xlsx"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href $=".xlsx"]::before,
-.b3-typography [href ^="assets/"][href $=".xlsx"]::before,
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href $=".xls"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href $=".xls"]::before,
-.b3-typography [href ^="assets/"][href $=".xls"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href $=".xlsx"]:first-child:not(:empty)::before,
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href $=".xls"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/fold/excel.svg');
 }
 
 /* pdf */
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href $=".pdf"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href $=".pdf"]::before,
-.b3-typography [href ^="assets/"][href $=".pdf"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href $=".pdf"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/fold/pdf.svg');
 }
 
 /* txt */
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href $=".txt"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href $=".txt"]::before,
-.b3-typography [href ^="assets/"][href $=".txt"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href $=".txt"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/fold/txt.svg');
 }
 
 /* 视频 */
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href $=".mp4"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href $=".mp4"]::before,
-.b3-typography [href ^="assets/"][href $=".mp4"]::before,
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href $=".m4v"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href $=".m4v"]::before,
-.b3-typography [href ^="assets/"][href $=".m4v"]::before,
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href $=".mov"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href $=".mov"]::before,
-.b3-typography [href ^="assets/"][href $=".mov"]::before,
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href $=".flv"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href $=".flv"]::before,
-.b3-typography [href ^="assets/"][href $=".flv"]::before,
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href $=".avi"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href $=".avi"]::before,
-.b3-typography [href ^="assets/"][href $=".avi"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href $=".mp4"]:first-child:not(:empty)::before,
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href $=".m4v"]:first-child:not(:empty)::before,
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href $=".mov"]:first-child:not(:empty)::before,
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href $=".flv"]:first-child:not(:empty)::before,
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href $=".avi"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/fold/MP4.svg');
 }
 
 /* 图片 */
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href $=".jpg"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href $=".jpg"]::before,
-.b3-typography [href ^="assets/"][href $=".jpg"]::before,
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href $=".png"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href $=".png"]::before,
-.b3-typography [href ^="assets/"][href $=".png"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href $=".jpg"]:first-child:not(:empty)::before,
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href $=".png"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/fold/jpg.svg');
 }
 
-/* html */
-/* .protyle-wysiwyg [data-node-id] span[data-type='a'][data-href $=".html"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href $=".html"]::before,
-.b3-typography [href ^="assets/"][href $=".html"]::before {
-    content: "";
-    background-image: url('/appearance/themes/Savor/icon/fold/html.svg');
-} */
-
 /* json */
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href $=".json"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href $=".json"]::before,
-.b3-typography [href ^="assets/"][href $=".json"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href $=".json"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/fold/json.svg');
 }
 
 /* css */
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href $=".css"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href $=".css"]::before,
-.b3-typography [href ^="assets/"][href $=".css"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href $=".css"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/fold/css.svg');
 }
 
 /* js,c++等 */
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href $=".java"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href $=".java"]::before,
-.b3-typography [href ^="assets/"][href $=".java"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href $=".java"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/fold/JAVA.svg');
 }
 
 /* js,c++等 */
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href $=".js"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href $=".js"]::before,
-.b3-typography [href ^="assets/"][href $=".js"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href $=".js"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/fold/vscode.svg');
 }
 
 /* xmind */
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href $=".xmind"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href $=".xmind"]::before,
-.b3-typography [href ^="assets/"][href $=".xmind"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href $=".xmind"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/fold/xmind.svg');
 }
 
 /* xmind */
-.protyle-wysiwyg [data-node-id] span[data-type='a'][data-href $=".md"]:not(:empty)::before,
-.protyle-wysiwyg [data-node-id] a[href $=".md"]::before,
-.b3-typography [href ^="assets/"][href $=".md"]::before {
+.protyle-wysiwyg [data-node-id] [contenteditable] span[data-type^='a'][data-href $=".md"]:first-child:not(:empty)::before{
     content: "";
     background-image: url('/appearance/themes/Savor/icon/fold/md.svg');
 }


### PR DESCRIPTION
修复链接文本关键词在搜索高亮时出现多个图标的问题
![图片](https://github.com/royc01/notion-theme/assets/68107073/41ad7ee9-cf61-4ac3-bb99-80bf1e901f6f)
![图片](https://github.com/royc01/notion-theme/assets/68107073/6dddd6f2-f4ff-4ac0-b711-93c44b25dcbe)
